### PR TITLE
range function returning correct range

### DIFF
--- a/addon/divide-into-pages.js
+++ b/addon/divide-into-pages.js
@@ -7,14 +7,14 @@ export default Ember.Object.extend({
   },
 
   totalPages: function() {
-    var allLength = parseFloat(this.get('all.length'));
-    var perPage = parseFloat(this.get('perPage'));
+    var allLength = parseInt(this.get('all.length'));
+    var perPage = parseInt(this.get('perPage'));
     return Math.ceil(allLength/perPage);
   },
 
   range: function(page) {
-    var perPage = this.get('perPage');
-    var s = (page - 1) * perPage;
+    var perPage = parseInt(this.get('perPage'));
+    var s = (parseInt(page) - 1) * perPage;
     var e = s + perPage - 1;
 
     return {start: s, end: e};


### PR DESCRIPTION
clicking on the 2nd page with perPage = 4 and length of content = 10, returns range as { s: 4, e: 43 } because perPage's type is string. 

```
e = 4 + "4" - 1
e = "44" - 1
e = "43"
```

It is fixed by using parseInt.
