### PR TITLE
Making it possible to update the list when the perPage quantity changes

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -47,5 +47,5 @@ export default Ember.ArrayProxy.extend(ArrayProxyPromiseMixin, {
 
   pageChanged: function() {
     this.set("promise", this.fetchContent());
-  }.observes("page")
+  }.observes("page", "perPage")
 });


### PR DESCRIPTION
I have a page that has an option to change the quantity of items perPage, to make it happen i had to extend remote/paged-remote-array.js and remote/route-mixin. 

Instead if the pageChanged function of paged-remote-array observes perPage either, it would work.
