### PR TITLE
By default the model being iterated has the same name of the route

### DIFF
--- a/addon/remote/route-mixin.js
+++ b/addon/remote/route-mixin.js
@@ -7,10 +7,13 @@ export default Ember.Mixin.create({
   startingPage: 1,
 
   model: function(params) {
-    var modelName = Ember.String.singularize(
-      Ember.String.camelize(this.get('routeName'))
-    );
-    return this.findPaged(modelName, params);
+    return this.findPaged(this._findModelName(this.get('routeName')), params);
+  },
+
+  _findModelName: function(routeName) {
+      return Ember.String.singularize(
+        Ember.String.camelize(routeName)
+      );
   },
 
   findPaged: function(name, params) {

--- a/tests/unit/mixins/route-mixin-remote-test.js
+++ b/tests/unit/mixins/route-mixin-remote-test.js
@@ -24,3 +24,29 @@ test("thing", function() {
   equal(findArgs[0].modelName,"todo");
   equal(findArgs[0].params.name,"Adam");
 });
+
+test("default model name", function() {  
+  var Route = Ember.Object.extend(RouteMixin, {});  
+  var route = Route.create();
+
+  equal('route', route._findModelName('route'));
+  equal('route', route._findModelName('routes'));
+  equal('routeName', route._findModelName('route-name'));
+  equal('routeName', route._findModelName('route-names'));
+});
+
+test("arguments passed to findPaged", function() {
+  var store = MockStore.create();
+
+  var Something = Ember.Object.extend(RouteMixin, {});
+  var something = Something.create({store: store});
+  something.set('routeName', 'todo');
+
+  something.model({name: "Adam"});
+  var findArgs = store.get('findArgs');
+
+  console.debug(findArgs);
+  equal(findArgs.length,1);
+  equal(findArgs[0].modelName,"todo");
+  equal(findArgs[0].params.name,"Adam");
+});


### PR DESCRIPTION
Creating a default implementation for the model function that assumes the model name is the same as the route.

It can be overridden, if any customization is needed 
