### PR TITLE
Convert other params to snake case

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -45,7 +45,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, ArrayProxyPromiseMixin, {
     for (var key in otherOps) {
       Util.log("otherOps key " + key);
       var val = otherOps[key];
-      ops[key] = val;
+      ops[key.underscore()] = val;
     }
 
     return ops;

--- a/tests/unit/lib/remote/paged-remote-array-test.js
+++ b/tests/unit/lib/remote/paged-remote-array-test.js
@@ -83,7 +83,7 @@ asyncTest("change page", function() {
   paged.then(function() {
     QUnit.start();
     equalArray(paged,[1,2]);
-    
+
     paged.runSet("page",2);
 
     paged.then(function() {
@@ -211,8 +211,12 @@ test("paramsForBackend with param mapping", function() {
   deepEqual(res,{currentPage: 1, per_page: 2});
 });
 
-
-
+test("paramsForBackend with otherParams converted to snakecased", function () {
+  var store = MockStore.create();
+  var paged = PagedRemoteArray.create({store: store, modelName: 'number', page: 1, perPage: 2, otherParams: {firstName: "Adam"}});
+  var res = paged.get('paramsForBackend');
+  deepEqual(res,{page: 1, per_page: 2, first_name: "Adam"});
+});
 
 asyncTest("basic meta", function() {
   var store = FakeStore.create({all: [1,2,3,4,5]});


### PR DESCRIPTION
To ensure other params follow Rails conventions, snake case other params when retrieving data from a remote endpoint.
