### PR TITLE
Add support for mapping functions

### DIFF
--- a/tests/unit/lib/remote/paged-remote-array-test.js
+++ b/tests/unit/lib/remote/paged-remote-array-test.js
@@ -211,6 +211,13 @@ test("paramsForBackend with param mapping", function() {
   deepEqual(res,{currentPage: 1, per_page: 2});
 });
 
+test("paramsForBackend with param mapping and function", function() {
+  var store = MockStore.create();
+  var paged = PagedRemoteArray.create({store: store, modelName: 'number', page: 1, perPage: 2});
+  paged.set('paramMapping', {page: ["currentPage", function(page, perPage) { return perPage + page; }]});
+  var res = paged.get('paramsForBackend');
+  deepEqual(res, {currentPage: 3, per_page: 2});
+});
 
 
 
@@ -233,6 +240,18 @@ asyncTest("meta with num_pages", function() {
   paged.then(function() {
     var meta = paged.get('meta');
     equal(meta.total_pages,3);
+    QUnit.start();
+  });
+});
+
+asyncTest("meta with num_pages and function", function() {
+  var store = FakeStore.create({all: [1,2,3,4,5], totalPagesField: 'num_pages'});
+  var paged = PagedRemoteArray.create({store: store, modelName: 'number', page: 1, perPage: 2});
+  paged.set('paramMapping',{total_pages: ['num_pages', function(val, page, perPage) { return val + page + perPage; }]});
+
+  paged.then(function() {
+    var meta = paged.get('meta');
+    equal(meta.total_pages,6);
     QUnit.start();
   });
 });


### PR DESCRIPTION
Basic support for mapping functions.

paramMapping now can take an array as value, first item of array is the string, second item is a function.

For the fields page and perPage, the function takes as arguments page and perPage.
For the field total_pages, the function takes as arguments the current value on meta, page and perPage.

It solves my issue with django tastypie backend, it might not be the best solution, but it's working and all tests pass.
