### PR TITLE
Add href attributes to links

### DIFF
--- a/app/templates/components/page-numbers.hbs
+++ b/app/templates/components/page-numbers.hbs
@@ -2,11 +2,11 @@
   <ul class="pagination">
     {{#if canStepBackward}}
       <li class="arrow prev enabled-arrow">
-        <a {{action "incrementPage" -1}}>&laquo;</a>
+        <a href="#" {{action "incrementPage" -1}}>&laquo;</a>
       </li>
     {{else}}
       <li class="arrow prev disabled">
-        <a {{action "incrementPage" -1}}>&laquo;</a>
+        <a href="#" {{action "incrementPage" -1}}>&laquo;</a>
       </li>
     {{/if}}
 
@@ -15,25 +15,25 @@
         <li class="dots disabled">
           <span>...</span>
         </li>
-      {{/if}} 
+      {{/if}}
       {{#if item.current}}
         <li class="active page-number">
-          <a>{{item.page}}</a>
+          <a href="#">{{item.page}}</a>
         </li>
       {{else}}
         <li class="page-number">
-          <a {{action "pageClicked" item.page}}>{{item.page}}</a>
+          <a href="#" {{action "pageClicked" item.page}}>{{item.page}}</a>
         </li>
       {{/if}}
     {{/each}}
 
     {{#if canStepForward}}
       <li class="arrow next enabled-arrow">
-        <a {{action "incrementPage" 1}}>&raquo;</a>
+        <a href="#" {{action "incrementPage" 1}}>&raquo;</a>
       </li>
     {{else}}
       <li class="arrow next disabled">
-        <a {{action "incrementPage" 1}}>&raquo;</a>
+        <a href="#" {{action "incrementPage" 1}}>&raquo;</a>
       </li>
     {{/if}}
   </ul>


### PR DESCRIPTION
Hi,

The `page-numbers` component doesn't display the correct cursor on hover.
To fix this the `<a>` balise should have an `href=` attribute.