### PR TITLE
Respect thenable semantics

### DIFF
--- a/addon/infinite/paged-infinite-array.js
+++ b/addon/infinite/paged-infinite-array.js
@@ -73,7 +73,7 @@ var c = InfiniteBase.extend({
   },
 
   then: function(f,f2) {
-    this.get('all').then(f,f2);
+    return this.get('all').then(f,f2);
   }
 });
 

--- a/addon/local/paged-array.js
+++ b/addon/local/paged-array.js
@@ -41,15 +41,20 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   then: function(success,failure) {
     var content = this.get('content');
     var me = this;
+    var promise;
 
     if (content.then) {
-      content.then(function() {
+      promise = content.then(function() {
         success(me);
       },failure);
     }
     else {
-      success(this);
+      promise = new Ember.RSVP.Promise(function(resolve) {
+        resolve(success(me));
+      });
     }
+    
+    return promise;
   },
 
   lockToRange: function() {

--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -9,7 +9,7 @@ var ArrayProxyPromiseMixin = Ember.Mixin.create(Ember.PromiseProxyMixin, {
     var promise = this.get('promise');
     var me = this;
 
-    promise.then(function() {
+    return promise.then(function() {
       success(me);
     }, failure);
   }


### PR DESCRIPTION
Hi there! 
I was trying to chain some promises while using a infinite paged array and bumped into a problem and was unable to do so. When checking the code I realized the `then` methods on the different paged arrays don't respect the usual `thenable` semantics, where the method should return a promise as well.
I modified the different paged arrays so they return an actual promise in every case, making the chaining posible.

Let me know if this change is acceptable for you and if I should add some test in any case.
Kudos for this great library! 
