### PR TITLE
Update paramsForBackend when otherParams changed

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -66,7 +66,7 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
     ops = Util.mergeHashes(ops,this.get('otherParams')||{});
 
     return ops;
-  }.property('page','perPage','paramMapping','paramsForBackendCounter'),
+  }.property('page','perPage','paramMapping', 'otherParams', 'paramsForBackendCounter'),
 
   rawFindFromStore: function() {
     var store = this.get('store');


### PR DESCRIPTION
Currently the ``paramsForBackend`` method is based on ``otherParams``, but the latter is not included in the watched properties list, so when ``otherParams`` is changed, ``paramsForBackend`` is not.

I didn't add a test here because I believe this to be a typo in the original file.