### PR TITLE
Add: support for nested pagination meta data

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -84,8 +84,27 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
     var me = this;
 
     res.then(function(rows) {
+      var meta = rows.meta;
+      var metaPaginationMapping = me.get('paramMapping.meta');
+      
+      if (metaPaginationMapping != null) {
+        if (typeof metaPaginationMapping === 'object') {
+          while(typeof metaPaginationMapping === 'object') {
+            for (var key in metaPaginationMapping) {
+              if (metaPaginationMapping.hasOwnProperty(key) && typeof(key) !== 'function') {
+                metaPaginationMapping = metaPaginationMapping[key]
+                meta = meta[key];
+                break;
+              }
+            }
+          }
+        } else {
+          meta = meta[metaPaginationMapping];
+        }
+      }
+      
       var metaObj = ChangeMeta.create({paramMapping: me.get('paramMapping'),
-                                       meta: rows.meta,
+                                       meta: meta,
                                        page: me.getPage(),
                                        perPage: me.getPerPage()});
 


### PR DESCRIPTION
As the name states I needed to support this for a project I'm working on as the meta data for pagination doesn't necessarily have to lie in the root of the meta object.

Example:

```javascript
{
  "authors": [
    {
      "id": "1",
      ...
    }
  ],
  "meta": {
    "pagination": {
      "total": 120,
      "count": 25,
      "per_page": 25,
      "current_page": 1,
      "total_pages": 5,
      "links": {
        "next": "http://..."
      }
    }
  }
}
```

The mapping would then be added to *paramMapping* for this example like this:

```javascript
params.paramMapping = { meta: "pagination" };
```

I suppose I could write tests for this too if I have more time. Take your time, review the code and let me know how you want to continue.

Regards,
David