### PR TITLE
.@each ember 2.0 deprecation

### DIFF
--- a/addon/infinite/paged-infinite-array.js
+++ b/addon/infinite/paged-infinite-array.js
@@ -42,7 +42,7 @@ var InfiniteBase = Ember.ArrayProxy.extend({
 
   arrangedContent: function() {
     return this.get('content');
-  }.property('content.@each'),
+  }.property('content.[]'),
 
   init: function() {
     this.set('content',[]);

--- a/addon/local/paged-array.js
+++ b/addon/local/paged-array.js
@@ -16,11 +16,11 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
 
   arrangedContent: function() {
     return this.divideObj().objsForPage(this.get('page'));
-  }.property("content.@each", "page", "perPage"),
+  }.property("content.[]", "page", "perPage"),
 
   totalPages: function() {
     return this.divideObj().totalPages();
-  }.property("content.@each", "perPage"),
+  }.property("content.[]", "perPage"),
   
   setPage: function(page) {
     Util.log("setPage " + page);

--- a/tests/unit/computed/paged-array-test.js
+++ b/tests/unit/computed/paged-array-test.js
@@ -165,7 +165,7 @@ test("filtered", function() {
         });
       }
       return res;
-    }.property("content.@each","min"),
+    }.property("content.[]","min"),
 
     pagedContent: pagedArray("filteredContent", {perPage: 2, pageBinding: "page"})
   });


### PR DESCRIPTION
Can't build to test due to a node version error, but the `.@each` deprecation warnings went away after updating this.