### PR TITLE
Update paged-remote-array.js

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -28,10 +28,10 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
     }
 
     try {
-      this.get('promise');
+      return this.get('promise');
     }
     catch (e) {
-      this.set('promise', this.fetchContent());
+      return this.set('promise', this.fetchContent());
     }
   },
 


### PR DESCRIPTION
need to return the promises from the paged-remote-array init, otherwise `findPaged` will not return a promise, which is required in a `model` hook for Ember's 'wait until promises are resolved' functionality.