### PR TITLE
Return promise for chaining

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -9,7 +9,7 @@ var ArrayProxyPromiseMixin = Ember.Mixin.create(Ember.PromiseProxyMixin, {
     var promise = this.get('promise');
     var me = this;
 
-    promise.then(function() {
+    return promise.then(function() {
       success(me);
     }, failure);
   }
@@ -57,8 +57,8 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
   },
 
   paramsForBackend: function() {
-    var paramsObj = QueryParamsForBackend.create({page: this.getPage(), 
-                                                  perPage: this.getPerPage(), 
+    var paramsObj = QueryParamsForBackend.create({page: this.getPage(),
+                                                  perPage: this.getPerPage(),
                                                   paramMapping: this.get('paramMapping')});
     var ops = paramsObj.make();
 
@@ -92,14 +92,14 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
 
       me.set("loading",false);
       return me.set("meta", metaObj.make());
-      
+
     }, function(error) {
       Util.log("PagedRemoteArray#fetchContent error " + error);
       me.set("loading",false);
     });
 
     return res;
-  },  
+  },
 
   totalPagesBinding: "meta.total_pages",
 


### PR DESCRIPTION
Wasn't able to `.finally()` on the remote promise bc it wasn't returned by the proxy mixin override of `then`.  Currently can't run tests bc:

>  WARNING: Please remove `ember-data` from `bower.json`. As of Ember Data 2.3.0, only the NPM package is needed. If you need an earlier version of ember-data (< 2.3.0), you can leave this unchanged for now, but we strongly suggest you upgrade your version of Ember Data as soon as possible.
Using a version of ember-cli-shims prior to 0.1.0 will cause errors while loading Ember Data 2.3.0-beta.3+. Please update ember-cli-shims from 0.0.6 to 0.1.0.