### PR TITLE
Fix deprecations for Ember 2.8.x

### DIFF
--- a/addon/computed/paged-array.js
+++ b/addon/computed/paged-array.js
@@ -10,7 +10,6 @@ function makeLocal(contentProperty,ops) {
     const getVal = function(key,val) {
       if (key.match(/Binding$/)) {
         return "parent."+val;
-        //return Ember.Binding.oneWay("parent."+val);
       }
       else {
         return val;
@@ -22,7 +21,7 @@ function makeLocal(contentProperty,ops) {
     }
 
     const paged = PagedArray.extend({
-      contentBinding: "parent."+contentProperty
+      content: Ember.computed.alias("parent."+contentProperty)
     }).create(pagedOps);
     // paged.lockToRange();
     return paged;

--- a/addon/remote/controller-mixin.js
+++ b/addon/remote/controller-mixin.js
@@ -3,10 +3,10 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   queryParams: ["page", "perPage"],
-  
-  pageBinding: "content.page",
 
-  totalPagesBinding: "content.totalPages",
+  page: Ember.computed.alias("content.page"),
 
-  pagedContentBinding: "content"
+  totalPages: Ember.computed.alias("content.totalPages"),
+
+  pagedContent: Ember.computed.alias("content")
 });

--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -57,8 +57,8 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
   },
 
   paramsForBackend: Ember.computed('page','perPage','paramMapping','paramsForBackendCounter', function() {
-    var paramsObj = QueryParamsForBackend.create({page: this.getPage(), 
-                                                  perPage: this.getPerPage(), 
+    var paramsObj = QueryParamsForBackend.create({page: this.getPage(),
+                                                  perPage: this.getPerPage(),
                                                   paramMapping: this.get('paramMapping')});
     var ops = paramsObj.make();
 
@@ -92,16 +92,16 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
 
       me.set("loading",false);
       return me.set("meta", metaObj.make());
-      
+
     }, function(error) {
       Util.log("PagedRemoteArray#fetchContent error " + error);
       me.set("loading",false);
     });
 
     return res;
-  },  
+  },
 
-  totalPagesBinding: "meta.total_pages",
+  totalPages: Ember.computed.alias("meta.total_pages"),
 
   pageChanged: Ember.observer("page", "perPage", function() {
     this.set("promise", this.fetchContent());

--- a/addon/util.js
+++ b/addon/util.js
@@ -16,7 +16,7 @@ Util.reopenClass({
     excludeKeys = Ember.A(excludeKeys);
     var res = [];
     for (var key in params) {
-      if (!excludeKeys.contains(key)) {
+      if (!excludeKeys.includes(key)) {
         res.push(key);
       }
     }

--- a/app/components/page-numbers.js
+++ b/app/components/page-numbers.js
@@ -4,8 +4,8 @@ import PageItems from 'ember-cli-pagination/lib/page-items';
 import Validate from 'ember-cli-pagination/validate';
 
 export default Ember.Component.extend({
-  currentPageBinding: "content.page",
-  totalPagesBinding: "content.totalPages",
+  currentPage: Ember.computed.alias("content.page"),
+  totalPages: Ember.computed.alias("content.totalPages"),
 
   hasPages: Ember.computed.gt('totalPages', 1),
 
@@ -33,15 +33,13 @@ export default Ember.Component.extend({
   pageItemsObj: Ember.computed(function() {
     return PageItems.create({
       parent: this,
-      currentPageBinding: "parent.currentPage",
-      totalPagesBinding: "parent.totalPages",
-      truncatePagesBinding: "parent.truncatePages",
-      numPagesToShowBinding: "parent.numPagesToShow",
-      showFLBinding: "parent.showFL"
+      currentPage: Ember.computed.alias("parent.currentPage"),
+      totalPages: Ember.computed.alias("parent.totalPages"),
+      truncatePages: Ember.computed.alias("parent.truncatePages"),
+      numPagesToShow: Ember.computed.alias("parent.numPagesToShow"),
+      showFL: Ember.computed.alias("parent.showFL")
     });
   }),
-
-  //pageItemsBinding: "pageItemsObj.pageItems",
 
   pageItems: Ember.computed("pageItemsObj.pageItems","pageItemsObj", function() {
     this.validate();

--- a/tests/unit/components/page-numbers-test.js
+++ b/tests/unit/components/page-numbers-test.js
@@ -24,12 +24,12 @@ test('hasPages', function(assert) {
   var s = this.subject();
 
   Ember.run(function() {
-    s.set('totalPages', 1);
+    s.set('content', {totalPages: 1});
   });
   assert.equal(s.get('hasPages'),false);
 
   Ember.run(function() {
-    s.set('totalPages', 2);
+    s.set('content', {totalPages: 2});
   });
   assert.equal(s.get('hasPages'),true);
 });
@@ -37,27 +37,27 @@ test('hasPages', function(assert) {
 test("canStepBackward", function(assert) {
   var s = this.subject();
   Ember.run(function() {
-    s.set("currentPage",1);
+    s.set("content", {currentPage: 1});
   });
   assert.equal(s.get('canStepBackward'),false);
 });
 
-paramTest("first page", {currentPage: 1, totalPages: 10}, function(s,assert) {
+paramTest("first page", {content: {page: 1, totalPages: 10}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),false);
   assert.equal(s.get('canStepForward'),true);
 });
 
-paramTest("last page page", {currentPage: 10, totalPages: 10}, function(s,assert) {
+paramTest("last page page", {content: {page: 10, totalPages: 10}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),true);
   assert.equal(s.get('canStepForward'),false);
 });
 
-paramTest("middle page", {currentPage: 5, totalPages: 10}, function(s,assert) {
+paramTest("middle page", {content: {page: 5, totalPages: 10}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),true);
   assert.equal(s.get('canStepForward'),true);
 });
 
-paramTest("only one page", {currentPage: 1, totalPages: 1}, function(s,assert) {
+paramTest("only one page", {content: {page: 1, totalPages: 1}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),false);
   assert.equal(s.get('canStepForward'),false);
 });
@@ -65,6 +65,7 @@ paramTest("only one page", {currentPage: 1, totalPages: 1}, function(s,assert) {
 
 var makePagedArray = function(list) {
   list = Ember.A(list);
+
   return PagedArray.create({content: list, perPage: 2, page: 1});
 };
 
@@ -121,7 +122,7 @@ paramTest("arrows and pages in right order", {content: makePagedArray([1,2,3,4,5
   assert.equal(pageItems.eq(4).hasClass("next"),true);
 });
 
-paramTest("truncation", {currentPage: 2, totalPages: 10, numPagesToShow: 5}, function(s,assert) {
+paramTest("truncation", {numPagesToShow: 5, content: {page: 2, totalPages: 10}}, function(s,assert) {
   var pages = s.get('pageItems').map(function(obj) {
     return obj.page;
   });
@@ -129,7 +130,7 @@ paramTest("truncation", {currentPage: 2, totalPages: 10, numPagesToShow: 5}, fun
   assert.deepEqual(pages,[1,2,3,4,5]);
 });
 
-paramTest("truncation with showFL = true", {currentPage: 2, totalPages: 10, numPagesToShow: 5, showFL: true}, function(s,assert) {
+paramTest("truncation with showFL = true", {showFL: true, numPagesToShow: 5, content: {page: 2, totalPages: 10}}, function(s,assert) {
   var pages = s.get('pageItems').map(function(obj) {
     return obj.page;
   });

--- a/tests/unit/computed/paged-array-test.js
+++ b/tests/unit/computed/paged-array-test.js
@@ -20,8 +20,6 @@ test("passing perPage to pagedArray", function(assert) {
   assert.deepEqual(res,[1,2]);
 });
 
-
-
 test("passing perPage and page to pagedArray", function(assert) {
   var Something = Ember.Object.extend({
     pagedContent: pagedArray("content", {perPage: 2, page: 2})
@@ -32,10 +30,9 @@ test("passing perPage and page to pagedArray", function(assert) {
   assert.deepEqual(toArray(object.get('pagedContent')),[3,4]);
 });
 
-
-test("passing pageBinding to pagedArray", function(assert) {
+test("passing page to pagedArray", function(assert) {
   var Something = Ember.Object.extend({
-    pagedContent: pagedArray("content", {perPage: 2, pageBinding: "page"})
+    pagedContent: pagedArray("content", {perPage: 2, page: 2})
   });
 
   var object = Something.create({
@@ -50,7 +47,7 @@ test("doing binding the other way", function(assert) {
   var Something = Ember.Object.extend({
     pagedContent: pagedArray("content", {perPage: 2}),
 
-    pageBinding: "pagedContent.page"
+    page: Ember.computed.alias("pagedContent.page")
   });
 
   var object = Something.create({
@@ -65,14 +62,13 @@ test("doing binding the other way", function(assert) {
   assert.deepEqual(toArray(object.get('pagedContent')),[3,4]);
 });
 
-test("passing perPageBinding to pagedArray", function(assert) {
+test("passing perPage to pagedArray", function(assert) {
   var Something = Ember.Object.extend({
-    pagedContent: pagedArray("content", {page: 1, perPageBinding: "perPage"})
+    pagedContent: pagedArray("content", {page: 1, perPage: 3})
   });
 
   var object = Something.create({
-    content: Ember.A([1,2,3,4,5]),
-    perPage: 3
+    content: Ember.A([1,2,3,4,5])
   });
 
   assert.deepEqual(toArray(object.get('pagedContent')),[1,2,3]);
@@ -110,27 +106,6 @@ test("pagedArray value changes when parent content property is modified", functi
   object.get("content").pushObject(6);
   assert.deepEqual(toArray(object.get('pagedContent')),[5,6]);
 });
-
-// test("pagedArray is locked to range by default", function() {
-//   var Something = Ember.Object.extend({
-//     pagedContent: pagedArray("content", {perPage: 2})
-//   });
-
-//   var object = Something.create({
-//     content: Ember.A([1,2,3,4,5])
-//   });
-
-//   deepEqual(toArray(object.get('pagedContent')),[1,2]);
-
-//   Ember.run(function() {
-//     object.get('pagedContent').set('page',99);
-//   });
-
-//   deepEqual(object.get('pagedContent.page'),3);
-
-//   // object.get("content").pushObject(6);
-//   // deepEqual(toArray(object.get('pagedContent')),[5,6]);
-// });
 
 test("infinite smoke", function(assert) {
   var Something = Ember.Object.extend({
@@ -175,7 +150,7 @@ test("filtered", function(assert) {
       return Ember.A(res);
     }),
 
-    pagedContent: pagedArray("filteredContent", {perPage: 2, pageBinding: "page"})
+    pagedContent: pagedArray("filteredContent", {"content.page": 2, perPage: 2})
   });
 
   var object = Something.create({
@@ -206,4 +181,3 @@ test("filtered", function(assert) {
   // object.get("content").pushObject(6);
   // deepEqual(toArray(object.get('pagedContent')),[5,6]);
 });
-

--- a/tests/unit/lib/remote/paged-remote-array-test.js
+++ b/tests/unit/lib/remote/paged-remote-array-test.js
@@ -100,30 +100,6 @@ asyncTest("change page", function(assert) {
   });
 });
 
-
-
-asyncTest("double start", function(assert) {
-  assert.expect(2);
-
-  var makePromise = function(res) {
-    return new Promise(function(success) {
-      setTimeout(function() {
-        success(res);
-      },5);
-    });
-  };
-
-  var promise = makePromise(3);
-  promise.then(function(res) {
-    assert.equal(res,3);
-
-    var promise2 = makePromise(5);
-    promise2.then(function(res2) {
-      assert.equal(res2,5);
-    });
-  });
-});
-
 var ErrorStore = Ember.Object.extend({
   find: function() {
     return new Promise(function(success,failure) {


### PR DESCRIPTION
This PR should fix both the Ember.Binding deprecation and the `.contains` deprecation.