### PR TITLE
Fix Ember binding deprecations for remote pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ export default Ember.ArrayController.extend({
 
   // binding the property on the paged array
   // to the query params on the controller
-  pageBinding: "content.page",
-  perPageBinding: "content.perPage",
-  totalPagesBinding: "content.totalPages",
+  page: Ember.computed.alias("content.page"),
+  perPage: Ember.computed.alias("content.perPage"),
+  totalPages: Ember.computed.alias("content.totalPages"),
 
   // set default values, can cause problems if left out
   // if value matches default, it won't display in the URL
@@ -166,7 +166,7 @@ export default Ember.ArrayController.extend({
 {{page-numbers content=content}}
 ```
 
-If you don't want to have query params, you may leave them out, along with the 3 bindings. The rest will still work.
+If you don't want to have query params, you may leave them out, along with the 3 computed aliases. The rest will still work.
 
 ### Passing other params to findPaged
 

--- a/addon/remote/controller-mixin.js
+++ b/addon/remote/controller-mixin.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 
 
 export default Ember.Mixin.create({
-  queryParams: ["page", "perPage"],
-  
-  pageBinding: "content.page",
+  queryParams: ["perPage"],
 
-  totalPagesBinding: "content.totalPages",
+  page: Ember.computed.alias("content.page"),
 
-  pagedContentBinding: "content"
+  totalPages: Ember.computed.alias("content.totalPages"),
+
+  pagedContent: Ember.computed.alias("content")
 });

--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -57,8 +57,8 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
   },
 
   paramsForBackend: Ember.computed('page','perPage','paramMapping','paramsForBackendCounter', function() {
-    var paramsObj = QueryParamsForBackend.create({page: this.getPage(), 
-                                                  perPage: this.getPerPage(), 
+    var paramsObj = QueryParamsForBackend.create({page: this.getPage(),
+                                                  perPage: this.getPerPage(),
                                                   paramMapping: this.get('paramMapping')});
     var ops = paramsObj.make();
 
@@ -92,16 +92,16 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
 
       me.set("loading",false);
       return me.set("meta", metaObj.make());
-      
+
     }, function(error) {
       Util.log("PagedRemoteArray#fetchContent error " + error);
       me.set("loading",false);
     });
 
     return res;
-  },  
+  },
 
-  totalPagesBinding: "meta.total_pages",
+  totalPages: Ember.computed.alias("meta.total_pages"),
 
   pageChanged: Ember.observer("page", "perPage", function() {
     this.set("promise", this.fetchContent());

--- a/app/components/page-numbers.js
+++ b/app/components/page-numbers.js
@@ -4,8 +4,8 @@ import PageItems from 'ember-cli-pagination/lib/page-items';
 import Validate from 'ember-cli-pagination/validate';
 
 export default Ember.Component.extend({
-  currentPageBinding: "content.page",
-  totalPagesBinding: "content.totalPages",
+  currentPage: Ember.computed.alias("content.page"),
+  totalPages: Ember.computed.alias("content.totalPages"),
 
   hasPages: Ember.computed.gt('totalPages', 1),
 
@@ -33,15 +33,13 @@ export default Ember.Component.extend({
   pageItemsObj: Ember.computed(function() {
     return PageItems.create({
       parent: this,
-      currentPageBinding: "parent.currentPage",
-      totalPagesBinding: "parent.totalPages",
-      truncatePagesBinding: "parent.truncatePages",
-      numPagesToShowBinding: "parent.numPagesToShow",
-      showFLBinding: "parent.showFL"
+      currentPage: Ember.computed.alias("parent.currentPage"),
+      totalPages: Ember.computed.alias("parent.totalPages"),
+      truncatePages: Ember.computed.alias("parent.truncatePages"),
+      numPagesToShow: Ember.computed.alias("parent.numPagesToShow"),
+      showFL: Ember.computed.alias("parent.showFL")
     });
   }),
-
-  //pageItemsBinding: "pageItemsObj.pageItems",
 
   pageItems: Ember.computed("pageItemsObj.pageItems","pageItemsObj", function() {
     this.validate();

--- a/tests/unit/components/page-numbers-test.js
+++ b/tests/unit/components/page-numbers-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { test, moduleForComponent } from 'ember-qunit';
 import PagedArray from 'ember-cli-pagination/local/paged-array';
 
-moduleForComponent("page-numbers");
+moduleForComponent("page-numbers", {unit: true});
 
 var paramTest = function(name,ops,f) {
   test(name, function(assert) {
@@ -24,12 +24,12 @@ test('hasPages', function(assert) {
   var s = this.subject();
 
   Ember.run(function() {
-    s.set('totalPages', 1);
+    s.set('content', {totalPages: 1});
   });
   assert.equal(s.get('hasPages'),false);
 
   Ember.run(function() {
-    s.set('totalPages', 2);
+    s.set('content', {totalPages: 2});
   });
   assert.equal(s.get('hasPages'),true);
 });
@@ -37,27 +37,27 @@ test('hasPages', function(assert) {
 test("canStepBackward", function(assert) {
   var s = this.subject();
   Ember.run(function() {
-    s.set("currentPage",1);
+    s.set('content', {page: 1});
   });
   assert.equal(s.get('canStepBackward'),false);
 });
 
-paramTest("first page", {currentPage: 1, totalPages: 10}, function(s,assert) {
+paramTest("first page", {content: {page: 1, totalPages: 10}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),false);
   assert.equal(s.get('canStepForward'),true);
 });
 
-paramTest("last page page", {currentPage: 10, totalPages: 10}, function(s,assert) {
+paramTest("last page page", {content: {page: 10, totalPages: 10}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),true);
   assert.equal(s.get('canStepForward'),false);
 });
 
-paramTest("middle page", {currentPage: 5, totalPages: 10}, function(s,assert) {
+paramTest("middle page", {content: {page: 5, totalPages: 10}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),true);
   assert.equal(s.get('canStepForward'),true);
 });
 
-paramTest("only one page", {currentPage: 1, totalPages: 1}, function(s,assert) {
+paramTest("only one page", {content: {page: 1, totalPages: 1}}, function(s,assert) {
   assert.equal(s.get('canStepBackward'),false);
   assert.equal(s.get('canStepForward'),false);
 });
@@ -97,19 +97,6 @@ paramTest("template smoke", {content: makePagedArray([1,2,3,4,5])}, function(s,a
   assert.equal(this.$().find(".next.enabled-arrow").length,1);
 });
 
-// COMMENTEDOUTTEST
-// paramTest("template smoke 2", {content: makePagedArray([1,2,3,4,5])}, function(s,assert) {
-//   this.append();
-
-//   hasPages(3);
-//   hasActivePage(1);
-
-//   clickPage(2);
-//   andThen(function() {
-//     hasActivePage(2);
-//   });
-// });
-
 paramTest("arrows and pages in right order", {content: makePagedArray([1,2,3,4,5])}, function(s,assert) {
   var pageItems = this.$().find("ul.pagination li");
   assert.equal(pageItems.length,5);
@@ -121,7 +108,7 @@ paramTest("arrows and pages in right order", {content: makePagedArray([1,2,3,4,5
   assert.equal(pageItems.eq(4).hasClass("next"),true);
 });
 
-paramTest("truncation", {currentPage: 2, totalPages: 10, numPagesToShow: 5}, function(s,assert) {
+paramTest("truncation", {content: {page: 2, totalPages: 10}, numPagesToShow: 5}, function(s,assert) {
   var pages = s.get('pageItems').map(function(obj) {
     return obj.page;
   });
@@ -129,7 +116,7 @@ paramTest("truncation", {currentPage: 2, totalPages: 10, numPagesToShow: 5}, fun
   assert.deepEqual(pages,[1,2,3,4,5]);
 });
 
-paramTest("truncation with showFL = true", {currentPage: 2, totalPages: 10, numPagesToShow: 5, showFL: true}, function(s,assert) {
+paramTest("truncation with showFL = true", {content: {page: 2, totalPages: 10}, numPagesToShow: 5, showFL: true}, function(s,assert) {
   var pages = s.get('pageItems').map(function(obj) {
     return obj.page;
   });

--- a/tests/unit/lib/remote/paged-remote-array-test.js
+++ b/tests/unit/lib/remote/paged-remote-array-test.js
@@ -100,30 +100,6 @@ asyncTest("change page", function(assert) {
   });
 });
 
-
-
-asyncTest("double start", function(assert) {
-  assert.expect(2);
-
-  var makePromise = function(res) {
-    return new Promise(function(success) {
-      setTimeout(function() {
-        success(res);
-      },5);
-    });
-  };
-
-  var promise = makePromise(3);
-  promise.then(function(res) {
-    assert.equal(res,3);
-
-    var promise2 = makePromise(5);
-    promise2.then(function(res2) {
-      assert.equal(res2,5);
-    });
-  });
-});
-
 var ErrorStore = Ember.Object.extend({
   find: function() {
     return new Promise(function(success,failure) {


### PR DESCRIPTION
This definitely isn't an exhaustive fix, but it gets the addon at least some of the way there. I believe that this fixes the Ember binding deprecations everywhere except for in `pagedArray`. I've never used the addon in that way, so I don't feel familiar enough with that part of the codebase to properly make changes to it (and also I couldn't find a working solution after 3 or 4 hours), so I'm just going to propose these changes for now as a start.