### PR TITLE
remove call to defineProperty when value is a number

### DIFF
--- a/addon/computed/paged-array.js
+++ b/addon/computed/paged-array.js
@@ -26,7 +26,7 @@ function makeLocal(contentProperty,ops) {
           // ^ deprecation warning based off of https://github.com/emberjs/ember.js/pull/13920/files
         }
         else {
-          Ember.defineProperty(pagedOps, key, value);
+          pagedOps[key] = value;
         }
       }
     }


### PR DESCRIPTION
@broerse Seems like there was one place where we shouldn't be using `Ember.defineProperty` because the `value` is a number, the page number.

fixes #251 
