### PR TITLE
fix sendAction deprecations

### DIFF
--- a/addon/components/page-numbers.js
+++ b/addon/components/page-numbers.js
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
     const c = this.get('content');
     if (c && c.on) {
       c.on('invalidPage', (e) => {
-        this.sendAction('invalidPageAction',e);
+        this.get('invalidPageAction')(e);
       });
     }
   }),
@@ -66,7 +66,7 @@ export default Ember.Component.extend({
     pageClicked: function(number) {
       Util.log("PageNumbers#pageClicked number " + number);
       this.set("currentPage", number);
-      this.sendAction('action',number);
+      this.get('action')(number);
     },
     incrementPage: function(num) {
       const currentPage = Number(this.get("currentPage")),
@@ -77,7 +77,7 @@ export default Ember.Component.extend({
       this.incrementProperty('currentPage', num);
 
       const newPage = this.get('currentPage');
-      this.sendAction('action',newPage);
+      this.get('action')(newPage);
     }
   }
 });


### PR DESCRIPTION
closes https://github.com/mharris717/ember-cli-pagination/issues/257

This changes the usage of sendAction to use closure actions.

I can't find anywhere in the source code where `invalidPageAction` or `action` is passed, so I assume these are optional actions?

If so I'll have to wrap them in `if this.get('invalidPageAction')` statements.