### PR TITLE
Fix promise chaining and create shallow copy of ops before passing to store.query

### DIFF
--- a/addon/local/paged-array.js
+++ b/addon/local/paged-array.js
@@ -45,7 +45,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
 
     if (content.then) {
       promise = content.then(function() {
-        success(me);
+        return success(me);
       },failure);
     }
     else {
@@ -53,7 +53,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
         resolve(success(me));
       });
     }
-    
+
     return promise;
   },
 

--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -10,7 +10,7 @@ var ArrayProxyPromiseMixin = Ember.Mixin.create(Ember.PromiseProxyMixin, {
     var me = this;
 
     return promise.then(function() {
-      success(me);
+      return success(me);
     }, failure);
   }
 });
@@ -89,7 +89,7 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
     var modelName = this.get('modelName');
 
     var ops = this.get('paramsForBackend');
-    var res = store.query(modelName, ops);
+    var res = store.query(modelName, Object.assign({},ops)); // always create a shallow copy of `ops` in case adapter would mutate the original object
 
     return res;
   },


### PR DESCRIPTION
We found two problems in the current code:
1. promises cannot be chained, there are missing `return`s
2. in case `ops` object passed to `store.query` is modified in `adapter` (eg. by deleting a property) it would cause inconsistency

I can split to two separate PRs if you think it would be better or if you are not interested in the second fix.